### PR TITLE
fix(run): update entrypoint input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
     description: 'Directory that contains the script code'
     required: false
     default: './'
-  entrypoint:
-    description: 'Entrypoint function of the script used when triggering an execution'
+  function:
+    description: 'Entrypoint function of the Apps Script script used when triggering an execution'
     required: false
     default: ''

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -40,7 +40,7 @@ func Run(ctx context.Context, cfg *config.Config) error {
 
 	// Trigger execution
 	req := &script.ExecutionRequest{
-		Function: cfg.Entrypoint,
+		Function: cfg.Function,
 	}
 
 	run, err := client.Scripts.Run(deploymentID, req).Do()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,7 +14,7 @@ func NewFromInputs(a *githubactions.Action) (*Config, error) {
 	cfg.AccessToken = a.GetInput(accessTokenInput)
 	cfg.ProjectId = a.GetInput(projectIdInput)
 	cfg.ScriptDir = a.GetInput(scriptDirInput)
-	cfg.Entrypoint = a.GetInput(entrypointInput)
+	cfg.Function = a.GetInput(functionInput)
 
 	// Validate
 	if cfg.AccessToken == "" || cfg.ProjectId == "" {

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -6,7 +6,7 @@ const (
 	accessTokenInput = "access-token"
 	projectIdInput   = "project-id"
 	scriptDirInput   = "script-dir"
-	entrypointInput  = "entrypoint"
+	functionInput    = "function"
 )
 
 // Allowed/supported commands
@@ -20,5 +20,5 @@ type Config struct {
 	AccessToken string
 	ProjectId   string
 	ScriptDir   string
-	Entrypoint  string
+	Function    string
 }


### PR DESCRIPTION
The input named `entrypoint` cannot be used as it interfers with the `ENTRYPOINT` directive of docker images. When running the image, it tries to run the submitted Apps Script function as entrypoint of the entire image (instead of the `gas-action` binary)