### PR TITLE
fix(run): use correct variable when listing deployments

### DIFF
--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -22,7 +22,7 @@ func Run(ctx context.Context, cfg *config.Config) error {
 	// Get latest versioned deployment
 	version := int64(1)
 	deploymentID := ""
-	existingDeployments, err := client.Projects.Deployments.List(cfg.ScriptDir).Do()
+	existingDeployments, err := client.Projects.Deployments.List(cfg.ProjectId).Do()
 	if err != nil {
 		return fmt.Errorf("error while listing existing deployments of script: %s", err)
 	}


### PR DESCRIPTION
Use project ID instead of script directory (which did not make any sense) when listing existing deployments